### PR TITLE
Several improvements for your nominatim module

### DIFF
--- a/nominatim/__init__.py
+++ b/nominatim/__init__.py
@@ -1,4 +1,4 @@
 """Nominatim API
 http://wiki.openstreetmap.org/wiki/Nominatim"""
 from __future__ import absolute_import
-from .nominatim import Nominatim, NominatimReverse
+from .nominatim import Nominatim, NominatimReverse, NominatimException

--- a/nominatim/nominatim.py
+++ b/nominatim/nominatim.py
@@ -1,73 +1,181 @@
+# changed by ibu radempa
+
+"""
+Access to the Nominatim API
+
+Nominatim is a tool to search openstreetmap data, see:
+  * https://wiki.openstreetmap.org/wiki/Nominatim
+  * https://wiki.openstreetmap.org/wiki/Category:Nominatim
+"""
+
 import json
 import logging
 import sys
 if sys.version_info.major == 2:
     import urllib2
+    from urllib import quote_plus
 else:
     import urllib.request as urllib2
+    from urllib.parse import quote_plus
+
+default_url = 'http://open.mapquestapi.com/nominatim/v1'
+"""
+URL of the default Nominatim instance
+"""
+
+zoom_aliases = {
+    'country': 0,
+    'megacity': 10,
+    'district': 10,
+    'city': 13,
+    'village': 15,
+    'street': 16,
+    'house': 18
+}
+"""
+Map zoom aliases to zoom levels
+"""
 
 
-class Nominatim(object):
-    """Class for querying text adress
+class NominatimException(Exception):
+    pass
 
-http://wiki.openstreetmap.org/wiki/Nominatim#Search"""
-    def __init__(self):
-        self.url = 'http://nominatim.openstreetmap.org/search?format=json'
+
+class NominatimRequest(object):
+    """
+    Abstract base class for connections to a Nominatim instance
+    """
+    def __init__(self, base_url=None):
+        """
+        Provide logging and set the Nominatim instance
+        (defaults to http://nominatim.openstreetmap.org )
+        """
         self.logger = logging.getLogger(__name__)
+        self.url = base_url.rstrip('/') if base_url is not None else default_url
 
-    def query(self, query, acceptlanguage='', limit=None):
-        """Method takes query string, acceptlanguage string (rfc2616 language 
-code), limit integer (limits number of results)."""
-        query = query.replace(' ', '+')
-        url = self.url
-        url += '&q=' + query
+    def request(self, url):
+        """
+        Send a http request to the given *url*, try to decode
+        the reply assuming it's JSON in UTF-8, and return the result
+
+        :returns: Decoded result, or None in case of an error
+        :rtype: mixed
+        """
+        self.logger.debug('url:\n' + url)
+        try:
+            response = urllib2.urlopen(url)
+            if response.code == 200:
+                result = json.loads(response.read().decode('utf-8'))
+                return result
+            else:
+                return None
+        except urllib2.URLError:
+            self.logger.info('Server connection problem')
+            return None
+
+
+class Nominatim(NominatimRequest):
+    """
+    Connections to a Nominatim instance for querying textual addresses
+
+    Cf. Nominatim documentation::
+
+        http://wiki.openstreetmap.org/wiki/Nominatim#Search
+    """
+    def __init__(self, base_url=None):
+        """
+        Set the Nominatim instance using its *base_url*;
+        defaults to http://nominatim.openstreetmap.org
+        """
+        super(Nominatim, self).__init__(base_url)
+        self.url += '/search?format=json'
+
+    def query(self, address, acceptlanguage=None, limit=20,
+              countrycodes=None):
+        """
+        Issue a geocoding query for *address* to the
+        Nominatim instance and return the decoded results
+
+        :param address: a query string with an address
+                        or presumed parts of an address
+        :type address: str or (if python2) unicode
+        :param acceptlanguage: rfc2616 language code
+        :type acceptlanguage: str or None
+        :param limit: limit the number of results
+        :type limit: int or None
+        :param countrycodes: restrict the search to countries
+             given by their ISO 3166-1alpha2 codes (cf.
+             https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 )
+        :type countrycodes: str iterable
+        :returns: a list of search results (each a dict)
+        :rtype: list or None
+        """
+        url = self.url + '&q=' + quote_plus(address)
         if acceptlanguage:
             url += '&accept-language=' + acceptlanguage
         if limit:
             url += '&limit=' + str(limit)
-        self.logger.debug('url:\n' + url)
-        try:
-            response = urllib2.urlopen(url)
-            if response.code == 200:
-                result = json.loads(response.read().decode('utf-8'))
-                return result
-            else:
-                return None
-        except urllib2.URLError:
-            self.logger.info('Server connection problem')
-            return None
-            pass
+        if countrycodes:
+            url += '&countrycodes=' + ','.join(countrycodes)
+        return self.request(url)
 
 
-class NominatimReverse(object):
-    """Class for querying gps coordinates
+class NominatimReverse(NominatimRequest):
+    """
+    Connections to a Nominatim instance for querying by
+    geographical coordinates
 
-http://wiki.openstreetmap.org/wiki/Nominatim#Reverse_Geocoding_.2F_Address_lookup"""
-    def __init__(self):
-        self.url = 'http://nominatim.openstreetmap.org/reverse?format=json'
-        self.logger = logging.getLogger(__name__)
+    Cf. Nominatim documentation::
 
-    def query(self, lat=None, lon=None, acceptlanguage='', zoom=18):
-        """Method takes lat and lon for GPS coordinates, acceptlanguage string,
-zoom integer (between from 0 to 18). """
+        http://wiki.openstreetmap.org/wiki/Nominatim#Reverse_Geocoding_.2F_Address_lookup
+    """
+    def __init__(self, base_url=None):
+        """
+        Set the Nominatim instance using its *base_url*;
+        defaults to http://nominatim.openstreetmap.org
+        """
+        super(NominatimReverse, self).__init__(base_url)
+        self.url += '/reverse?format=json'
+
+    def query(self, lat=None, lon=None, osm_id=None, osm_type=None,
+              acceptlanguage='', zoom=18):
+        """
+        Issue a reverse geocoding query for a place given
+        by *lat* and *lon*, or by *osm_id* and *osm_type*
+        to the Nominatim instance and return the decoded results
+
+        :param lat: the geograpical latitude of the place
+        :param lon: the geograpical longitude of the place
+        :param osm_id: openstreetmap identifier osm_id
+        :type osm_id: str
+        :param osm_type: openstreetmap type osm_type
+        :type osm_type: str
+        :param acceptlanguage: rfc2616 language code
+        :type acceptlanguage: str or None
+        :param zoom: zoom factor between from 0 to 18
+        :type zoom: int or None or a key in :data:`zoom_aliases`
+        :param countrycodes: restrict the search to countries
+             given by their ISO 3166-1alpha2 codes (cf.
+             https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 )
+        :type countrycodes: str iterable
+        :returns: a list of search results (each a dict)
+        :rtype: list or None
+        :raise: NominatimException if invalid zoom value
+        """
         url = self.url
-        if lat and lon:
+        if osm_id is not None and osm_type not in ('N', 'W', 'R'):
+            raise NominatimException('invalid osm_type')
+        if osm_id is not None and osm_type is not None:
+            url += '&osm_id=' + osm_id + '&osm_type=' + osm_type
+        elif lat is not None and lon is not None:
             url += '&lat=' + str(lat) + '&lon=' + str(lon)
+        else:
+            return None
         if acceptlanguage:
             url += '&accept-language=' + acceptlanguage
-        if zoom < 0 or zoom > 18:
-            raise Exception('zoom must be betwen 0 and 18')
+        if zoom in zoom_aliases:
+            zoom = zoom_aliases[zoom]
+        if not isinstance(zoom, int) or zoom < 0 or zoom > 18:
+            raise NominatimException('zoom must effectively be betwen 0 and 18')
         url +='&zoom=' + str(zoom)
-        self.logger.debug('url:\n' + url)
-        try:
-            response = urllib2.urlopen(url)
-            if response.code == 200:
-                result = json.loads(response.read().decode('utf-8'))
-                return result
-            else:
-                return None
-        except urllib2.URLError:
-            self.logger.info('Server connection problem')
-            return None
-            pass
-
+        return self.request(url)

--- a/tests/test_nominatim.py
+++ b/tests/test_nominatim.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from nominatim import *
+
+
+def result_has_osm_id(res, osm_id):
+    for r in res:
+        if r['osm_id'] == osm_id:
+            return True
+    return False
+
+def address_has_city(address, city):
+    if not isinstance(address, dict):
+        return False
+    if not 'city' in address:
+        return False
+    return address['city'] == city
+
+
+class TestNominatim(unittest.TestCase):
+    def test_geocoding_default_url(self):
+        n = Nominatim()
+        location = 'Helsinki'
+        res = n.query(location)
+        self.assertTrue(result_has_osm_id(res, '34914'))
+
+    def test_geocoding_osm_url(self):
+        n = Nominatim('http://nominatim.openstreetmap.org')
+        location = 'Helsinki'
+        res = n.query(location)
+        self.assertTrue(result_has_osm_id(res, '34914'))
+
+    def test_reverse_geocoding_default_url(self):
+        n = NominatimReverse()
+        lat = 60.1666277
+        lon = 24.9435079
+        res = n.query(lat=lat, lon=lon, zoom='city')
+        self.assertTrue(isinstance(res, dict))
+        self.assertTrue('address' in  res)
+        self.assertTrue(address_has_city(res['address'], 'Helsinki'))
+
+    def test_reverse_geocoding_osm_url(self):
+        n = NominatimReverse('http://nominatim.openstreetmap.org')
+        lat = 60.1666277
+        lon = 24.9435079
+        res = n.query(lat=lat, lon=lon, zoom='city')
+        self.assertTrue(isinstance(res, dict))
+        self.assertTrue('address' in  res)
+        self.assertTrue(address_has_city(res['address'], 'Helsinki'))
+
+    def test_reverse_geocoding_from_osm_id_default_url(self):
+        n = NominatimReverse()
+        osm_id = '184705'
+        osm_type = 'R'
+        res = n.query(osm_id=osm_id, osm_type=osm_type, zoom='city')
+        self.assertTrue(isinstance(res, dict))
+        self.assertTrue('address' in  res)
+        self.assertTrue(address_has_city(res['address'], 'Helsinki'))
+
+    def test_reverse_geocoding_from_osm_id_osm_url(self):
+        n = NominatimReverse('http://nominatim.openstreetmap.org')
+        osm_id = '184705'
+        osm_type = 'R'
+        res = n.query(osm_id=osm_id, osm_type=osm_type, zoom='city')
+        self.assertTrue(isinstance(res, dict))
+        self.assertTrue('address' in  res)
+        self.assertTrue(address_has_city(res['address'], 'Helsinki'))
+
+    def test_invalid_osm_type(self):
+        n = NominatimReverse()
+        with self.assertRaises(NominatimException):
+            osm_id = '184705'
+            osm_type = 'X'
+            res = n.query(osm_id=osm_id, osm_type=osm_type, zoom='city')


### PR DESCRIPTION
- polishing of code and documentation
- add few unittests; run them from the project home with:
  python -m unittest discover
- changed default Nominatim instance to
  http://open.mapquestapi.com/nominatim/v1
  to avoid overloading of openstreetmap
  (s. http://wiki.openstreetmap.org/wiki/Nominatim_usage_policy )
- add option osm_id plus osm_type to NominatimReverse
- add zoom aliases (NominatimReverse)
- add countrycodes selection
- add url options to choose Nominatim instance
- add NominatimException
- factor out the HTTP request to NominatimRequest
- fix lat==0 or lon==0 leading to no result
- fix URL encoding
